### PR TITLE
Suggestion to configure the main pom.xml using maven plugins for embedded servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,21 @@
 					<target>${javase.version}</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>net.wasdev.wlp.maven.plugins</groupId>
+				<artifactId>liberty-maven-plugin</artifactId>
+				<version>1.1</version>
+				<configuration>
+					<configFile>src/main/servers/wlp/server.xml</configFile>
+					<bootstrapProperties>
+						<application.location>../../../../../${project.build.finalName}</application.location>
+						<application.name>${project.artifactId}</application.name>
+						<default.http.port>9080</default.http.port>
+						<default.https.port>9444</default.https.port>
+					</bootstrapProperties>
+					<serverName>showcaseServer</serverName>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/servers/wlp/server.xml
+++ b/src/main/servers/wlp/server.xml
@@ -1,0 +1,16 @@
+<server description="The server for showcases">
+	<!-- Enable features -->
+	<featureManager>
+		<feature>servlet-3.1</feature>
+		<feature>jsf-2.2</feature>
+		<feature>cdi-1.2</feature>
+		<feature>jndi-1.0</feature>
+		<feature>websocket-1.1</feature>
+	</featureManager>
+
+	<httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" 
+			id="defaultHttpEndpoint"/>
+
+	<application context-root="${application.name}" type="war" id="${application.name}" 
+			location="${application.location}" name="${application.name}"/>
+</server>


### PR DESCRIPTION
### My suggestion

It could make easy to show the **Omnifaces power** for new adoptions if we do deploy and starting of the project just by one click.

I added the WebSphere Liberty Profile plugin configuration and now we can download the JavaEE7 web profile, create the server and deploy the application just by the following maven command:

```bash
$ mvn liberty:run-server
```
The WebSphere Liberty maven plugin is described here: [https://github.com/WASdev/ci.maven](https://github.com/WASdev/ci.maven).

### Profiles

If it is more preferable I can add the Liberty plugin as a part of a maven profile and then other developers can add configurations for Tomcat, Jetty, whatever as other profiles.

### Other PR

Oh, there is a [PR](https://github.com/omnifaces/showcase/pull/6) is opened for the similar suggestion.