### PR TITLE
Java 8 DateTime API is used but javase.version 1.7 was specified. Fixed!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<javase.version>1.7</javase.version>
+		<javase.version>1.8</javase.version>
 		<javaee.version>7.0</javaee.version>
 	</properties>
 


### PR DESCRIPTION
Java 8 DateTime API is used, please see the org.omnifaces.showcase.PageView class. The maven variable <javase.version> is just changed.